### PR TITLE
Add archive categories and example pages

### DIFF
--- a/arts.html
+++ b/arts.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Archive - h000000nkim</title>
+  <title>Arts - h000000nkim</title>
   <link rel="stylesheet" href="styles.css">
   <script src="scripts.js"></script>
 </head>
@@ -21,29 +21,10 @@
     </nav>
   </header>
   <main>
-    <div class="archive-container">
-      <section class="archive-content">
-        <h2>Archive</h2>
-        <p>A list of archived works will appear here.</p>
-        <ul>
-          <li>Sample Item 1</li>
-          <li>Sample Item 2</li>
-          <li>Sample Item 3</li>
-        </ul>
-      </section>
-      <aside class="archive-sidebar">
-        <h3>Categories</h3>
-        <ul>
-          <li><a href="math.html">Math</a></li>
-          <li><a href="natural-language-process.html">Natural Language Process</a></li>
-          <li><a href="statistics.html">Statistics</a></li>
-          <li><a href="test-theory.html">Test Theory</a></li>
-          <li><a href="python.html">Python</a></li>
-          <li><a href="arts.html">Arts</a></li>
-          <li><a href="music.html">Music</a></li>
-        </ul>
-      </aside>
-    </div>
+    <section>
+      <h2>Arts</h2>
+      <p>This is an example page for the Arts category.</p>
+    </section>
   </main>
   <footer>
     <p>&copy; 2025 h000000nkim</p>
@@ -54,3 +35,4 @@
   </footer>
 </body>
 </html>
+

--- a/math.html
+++ b/math.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Archive - h000000nkim</title>
+  <title>Math - h000000nkim</title>
   <link rel="stylesheet" href="styles.css">
   <script src="scripts.js"></script>
 </head>
@@ -21,29 +21,10 @@
     </nav>
   </header>
   <main>
-    <div class="archive-container">
-      <section class="archive-content">
-        <h2>Archive</h2>
-        <p>A list of archived works will appear here.</p>
-        <ul>
-          <li>Sample Item 1</li>
-          <li>Sample Item 2</li>
-          <li>Sample Item 3</li>
-        </ul>
-      </section>
-      <aside class="archive-sidebar">
-        <h3>Categories</h3>
-        <ul>
-          <li><a href="math.html">Math</a></li>
-          <li><a href="natural-language-process.html">Natural Language Process</a></li>
-          <li><a href="statistics.html">Statistics</a></li>
-          <li><a href="test-theory.html">Test Theory</a></li>
-          <li><a href="python.html">Python</a></li>
-          <li><a href="arts.html">Arts</a></li>
-          <li><a href="music.html">Music</a></li>
-        </ul>
-      </aside>
-    </div>
+    <section>
+      <h2>Math</h2>
+      <p>This is an example page for the Math category.</p>
+    </section>
   </main>
   <footer>
     <p>&copy; 2025 h000000nkim</p>
@@ -54,3 +35,4 @@
   </footer>
 </body>
 </html>
+

--- a/music.html
+++ b/music.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Archive - h000000nkim</title>
+  <title>Music - h000000nkim</title>
   <link rel="stylesheet" href="styles.css">
   <script src="scripts.js"></script>
 </head>
@@ -21,29 +21,10 @@
     </nav>
   </header>
   <main>
-    <div class="archive-container">
-      <section class="archive-content">
-        <h2>Archive</h2>
-        <p>A list of archived works will appear here.</p>
-        <ul>
-          <li>Sample Item 1</li>
-          <li>Sample Item 2</li>
-          <li>Sample Item 3</li>
-        </ul>
-      </section>
-      <aside class="archive-sidebar">
-        <h3>Categories</h3>
-        <ul>
-          <li><a href="math.html">Math</a></li>
-          <li><a href="natural-language-process.html">Natural Language Process</a></li>
-          <li><a href="statistics.html">Statistics</a></li>
-          <li><a href="test-theory.html">Test Theory</a></li>
-          <li><a href="python.html">Python</a></li>
-          <li><a href="arts.html">Arts</a></li>
-          <li><a href="music.html">Music</a></li>
-        </ul>
-      </aside>
-    </div>
+    <section>
+      <h2>Music</h2>
+      <p>This is an example page for the Music category.</p>
+    </section>
   </main>
   <footer>
     <p>&copy; 2025 h000000nkim</p>
@@ -54,3 +35,4 @@
   </footer>
 </body>
 </html>
+

--- a/natural-language-process.html
+++ b/natural-language-process.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Archive - h000000nkim</title>
+  <title>Natural Language Process - h000000nkim</title>
   <link rel="stylesheet" href="styles.css">
   <script src="scripts.js"></script>
 </head>
@@ -21,29 +21,10 @@
     </nav>
   </header>
   <main>
-    <div class="archive-container">
-      <section class="archive-content">
-        <h2>Archive</h2>
-        <p>A list of archived works will appear here.</p>
-        <ul>
-          <li>Sample Item 1</li>
-          <li>Sample Item 2</li>
-          <li>Sample Item 3</li>
-        </ul>
-      </section>
-      <aside class="archive-sidebar">
-        <h3>Categories</h3>
-        <ul>
-          <li><a href="math.html">Math</a></li>
-          <li><a href="natural-language-process.html">Natural Language Process</a></li>
-          <li><a href="statistics.html">Statistics</a></li>
-          <li><a href="test-theory.html">Test Theory</a></li>
-          <li><a href="python.html">Python</a></li>
-          <li><a href="arts.html">Arts</a></li>
-          <li><a href="music.html">Music</a></li>
-        </ul>
-      </aside>
-    </div>
+    <section>
+      <h2>Natural Language Process</h2>
+      <p>This is an example page for the Natural Language Process category.</p>
+    </section>
   </main>
   <footer>
     <p>&copy; 2025 h000000nkim</p>
@@ -54,3 +35,4 @@
   </footer>
 </body>
 </html>
+

--- a/python.html
+++ b/python.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Archive - h000000nkim</title>
+  <title>Python - h000000nkim</title>
   <link rel="stylesheet" href="styles.css">
   <script src="scripts.js"></script>
 </head>
@@ -21,29 +21,10 @@
     </nav>
   </header>
   <main>
-    <div class="archive-container">
-      <section class="archive-content">
-        <h2>Archive</h2>
-        <p>A list of archived works will appear here.</p>
-        <ul>
-          <li>Sample Item 1</li>
-          <li>Sample Item 2</li>
-          <li>Sample Item 3</li>
-        </ul>
-      </section>
-      <aside class="archive-sidebar">
-        <h3>Categories</h3>
-        <ul>
-          <li><a href="math.html">Math</a></li>
-          <li><a href="natural-language-process.html">Natural Language Process</a></li>
-          <li><a href="statistics.html">Statistics</a></li>
-          <li><a href="test-theory.html">Test Theory</a></li>
-          <li><a href="python.html">Python</a></li>
-          <li><a href="arts.html">Arts</a></li>
-          <li><a href="music.html">Music</a></li>
-        </ul>
-      </aside>
-    </div>
+    <section>
+      <h2>Python</h2>
+      <p>This is an example page for the Python category.</p>
+    </section>
   </main>
   <footer>
     <p>&copy; 2025 h000000nkim</p>
@@ -54,3 +35,4 @@
   </footer>
 </body>
 </html>
+

--- a/statistics.html
+++ b/statistics.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Archive - h000000nkim</title>
+  <title>Statistics - h000000nkim</title>
   <link rel="stylesheet" href="styles.css">
   <script src="scripts.js"></script>
 </head>
@@ -21,29 +21,10 @@
     </nav>
   </header>
   <main>
-    <div class="archive-container">
-      <section class="archive-content">
-        <h2>Archive</h2>
-        <p>A list of archived works will appear here.</p>
-        <ul>
-          <li>Sample Item 1</li>
-          <li>Sample Item 2</li>
-          <li>Sample Item 3</li>
-        </ul>
-      </section>
-      <aside class="archive-sidebar">
-        <h3>Categories</h3>
-        <ul>
-          <li><a href="math.html">Math</a></li>
-          <li><a href="natural-language-process.html">Natural Language Process</a></li>
-          <li><a href="statistics.html">Statistics</a></li>
-          <li><a href="test-theory.html">Test Theory</a></li>
-          <li><a href="python.html">Python</a></li>
-          <li><a href="arts.html">Arts</a></li>
-          <li><a href="music.html">Music</a></li>
-        </ul>
-      </aside>
-    </div>
+    <section>
+      <h2>Statistics</h2>
+      <p>This is an example page for the Statistics category.</p>
+    </section>
   </main>
   <footer>
     <p>&copy; 2025 h000000nkim</p>
@@ -54,3 +35,4 @@
   </footer>
 </body>
 </html>
+

--- a/styles.css
+++ b/styles.css
@@ -37,3 +37,31 @@ body.scrolled {
 body.hide-header main {
   padding-top: 60px; /* space for fixed header */
 }
+
+/* Archive layout */
+.archive-container {
+  display: flex;
+}
+
+.archive-content {
+  flex: 1;
+}
+
+.archive-sidebar {
+  width: 200px;
+  margin-left: 2rem;
+}
+
+.archive-sidebar ul {
+  list-style: none;
+  padding: 0;
+}
+
+.archive-sidebar li {
+  margin-bottom: 0.5rem;
+}
+
+.archive-sidebar a {
+  text-decoration: none;
+  color: inherit;
+}

--- a/test-theory.html
+++ b/test-theory.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Archive - h000000nkim</title>
+  <title>Test Theory - h000000nkim</title>
   <link rel="stylesheet" href="styles.css">
   <script src="scripts.js"></script>
 </head>
@@ -21,29 +21,10 @@
     </nav>
   </header>
   <main>
-    <div class="archive-container">
-      <section class="archive-content">
-        <h2>Archive</h2>
-        <p>A list of archived works will appear here.</p>
-        <ul>
-          <li>Sample Item 1</li>
-          <li>Sample Item 2</li>
-          <li>Sample Item 3</li>
-        </ul>
-      </section>
-      <aside class="archive-sidebar">
-        <h3>Categories</h3>
-        <ul>
-          <li><a href="math.html">Math</a></li>
-          <li><a href="natural-language-process.html">Natural Language Process</a></li>
-          <li><a href="statistics.html">Statistics</a></li>
-          <li><a href="test-theory.html">Test Theory</a></li>
-          <li><a href="python.html">Python</a></li>
-          <li><a href="arts.html">Arts</a></li>
-          <li><a href="music.html">Music</a></li>
-        </ul>
-      </aside>
-    </div>
+    <section>
+      <h2>Test Theory</h2>
+      <p>This is an example page for the Test Theory category.</p>
+    </section>
   </main>
   <footer>
     <p>&copy; 2025 h000000nkim</p>
@@ -54,3 +35,4 @@
   </footer>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Add sidebar list of archive categories.
- Create example pages for Math, Natural Language Process, Statistics, Test Theory, Python, Arts, and Music.
- Style new archive layout with CSS flexbox.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68944f4d3ea48325809a03e0054dab21